### PR TITLE
Add dataset-level CIELab colour difference functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Encoding: UTF-8
 Imports:
     agricolae (>= 1.3-7),
     dplyr (>= 1.1.4),
+    farver (>= 2.1.0),
     gtools (>= 3.9.5),
     openxlsx (>= 4.2.5.2),
     rlang (>= 0.4.11),


### PR DESCRIPTION
Add calc_color_diff() for centroid-to-centroid comparisons and calc_pairwise_dE() for observation-level pairwise comparisons. These complement the existing point-level functions by enabling group-based colour analysis across experimental conditions.

https://claude.ai/code/session_013GMLLGQiB2GxcAwGwZRR4f