### PR TITLE
Fix path length correction logic in cielab_from_spectrum test

### DIFF
--- a/tests/testthat/test_cielab.R
+++ b/tests/testthat/test_cielab.R
@@ -234,14 +234,15 @@ test_that("cielab_from_spectrum handles path length correction", {
   # 10mm path length (default)
   result_10mm <- cielab_from_spectrum(wine_data, path_mm = 10)
 
-  # 5mm path length - should give higher L* (less absorption)
+  # 5mm path length - when claiming data was measured at 5mm, the function
+  # scales absorbance UP to 10mm equivalent, resulting in lower L* (darker)
   result_5mm <- cielab_from_spectrum(wine_data, path_mm = 5)
 
-  # Red wine should appear lighter at 5mm path length
+  # Red wine should appear darker when path length correction scales up absorbance
   red_10mm <- result_10mm[result_10mm$WineName == "RedWine", "CIELab_L"]
   red_5mm <- result_5mm[result_5mm$WineName == "RedWine", "CIELab_L"]
 
-  expect_true(red_5mm > red_10mm)
+  expect_true(red_5mm < red_10mm)
 })
 
 test_that("cielab_from_spectrum auto-detects sample column",


### PR DESCRIPTION
## Summary
Corrected the test expectations and documentation for path length correction in the `cielab_from_spectrum` function to accurately reflect the actual behavior of the implementation.

## Key Changes
- **Updated test assertion**: Changed `expect_true(red_5mm > red_10mm)` to `expect_true(red_5mm < red_10mm)` to match the actual behavior
- **Clarified documentation**: Updated comments to correctly explain that when data is claimed to be measured at 5mm path length, the function scales absorbance UP to 10mm equivalent, resulting in darker appearance (lower L* values)
- **Fixed logical error**: The previous test expected lighter appearance at shorter path length, which contradicted the actual implementation behavior

## Implementation Details
The path length correction works by scaling absorbance values. When a shorter path length (5mm) is specified for data that will be normalized to a standard 10mm reference:
- Absorbance is scaled upward (higher absorption values)
- This results in lower L* (lightness) values
- The sample appears darker in the resulting CIELAB color space

This fix ensures the test accurately validates the function's behavior rather than expecting incorrect results.

https://claude.ai/code/session_01WCXbeaQTwG4h5RA666haM4