### PR TITLE
Fix Residuals row inclusion in aovInteractSummaryTable

### DIFF
--- a/R/anova_summary.funct.R
+++ b/R/anova_summary.funct.R
@@ -201,7 +201,10 @@ aovInteractSummaryTable <- function(aov_data,
     temp_aov <- aov(formula, data = aov_data)
     aov_summary <- summary(temp_aov)[[1]]
     # Get effect names (excluding Residuals)
-    effect_names <- rownames(aov_summary)[rownames(aov_summary) != "Residuals"]
+    # Note: rownames from summary(aov()) have trailing whitespace, so we must
+    # trim before comparing.
+    effect_names <- trimws(rownames(aov_summary))
+    effect_names <- effect_names[effect_names != "Residuals"]
   }
 
   # Create row labels with separate rows for each effect's statistics
@@ -231,6 +234,7 @@ aovInteractSummaryTable <- function(aov_data,
 
     # Extract ALL effects' p-values and F-values (not just the first row)
     aov_summary <- summary(t.anova)[[1]]
+    rownames(aov_summary) <- trimws(rownames(aov_summary))
     effect_stats <- c()
     for (effect in effect_names) {
       if (effect %in% rownames(aov_summary)) {

--- a/tests/testthat/test_aovInteractSummaryTable.R
+++ b/tests/testthat/test_aovInteractSummaryTable.R
@@ -30,3 +30,13 @@ test_that("aovInteractSummaryTable produces a valid data frame with greenhouse d
   expect_true(all(sapply(result, is.character) | sapply(result, is.numeric)))
 })
 
+test_that("aovInteractSummaryTable does not include Residuals rows", {
+  greenhouse1_data <- greenhouse$greenhouse1
+
+  result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+
+  # No Type label should contain "Residuals"
+  residual_rows <- grep("Residuals", result$Type, value = TRUE)
+  expect_length(residual_rows, 0)
+})
+


### PR DESCRIPTION
## Summary
Fixed a bug in `aovInteractSummaryTable` where Residuals rows were being incorrectly included in the output due to trailing whitespace in row names from `summary(aov())`.

## Changes
- **Root cause**: Row names extracted from `summary(aov())` contain trailing whitespace, causing the string comparison `rownames(aov_summary) != "Residuals"` to fail
- **Fix applied**: 
  - Added `trimws()` call to remove leading/trailing whitespace from all row names before filtering
  - Applied the fix in two locations: initial effect name extraction and within the loop that processes multiple ANOVA objects
  - Added explanatory comment documenting the whitespace issue
- **Test coverage**: Added test case to verify that Residuals rows are properly excluded from the output

## Implementation Details
The fix uses `trimws()` to normalize row names before comparison, ensuring that the Residuals row is correctly filtered out regardless of whitespace formatting from the underlying `aov()` summary function.

https://claude.ai/code/session_01LvxnAHSXvkbAsFpWVNAi2r