### PR TITLE
Handle invariant columns in ANOVA summary functions

### DIFF
--- a/R/anova_summary.funct.R
+++ b/R/anova_summary.funct.R
@@ -46,7 +46,7 @@ aovSummaryTable <- function(aov_data,
   
   # Skip factor columns.
   factor_indices <- which(sapply(aov_data, is.factor))
-  
+
   # Loop over each column.
   for (i in 1:ncol(aov_data)) {
     if (i %in% factor_indices) next
@@ -54,8 +54,13 @@ aovSummaryTable <- function(aov_data,
       stop(paste("Error: Column", colnames(aov_data)[i], "is not numeric or factor."))
     }
     columnname <- colnames(aov_data)[i]
-    
-    if (length(unique(aov_data[[i]])) == 1) {
+
+    # Check invariance: constant response OR group_var has <2 levels after NA removal.
+    non_na_data <- aov_data[!is.na(aov_data[[i]]), ]
+    col_is_invariant <- length(unique(aov_data[[i]])) == 1 ||
+      length(unique(non_na_data[[group_var]])) < 2
+
+    if (col_is_invariant) {
       # For invariant columns, fill with "invariant".
       summary_table[[columnname]] <- rep("invariant", length(base_rows))
     } else {
@@ -178,16 +183,35 @@ aovInteractSummaryTable <- function(aov_data,
   
   summary_list <- list()
   row_names_list <- list()
+  invariant_cols <- c()
   pvalues_vec <- c()
-  
+
+  # Helper: TRUE if the column is effectively invariant for ANOVA purposes —
+  # either the response is constant, or any group_var has <2 levels after
+  # removing NAs for that column (which would cause the "contrasts" error).
+  col_is_invariant <- function(col_name) {
+    col_vals <- aov_data[[col_name]]
+    if (length(unique(col_vals)) <= 1) return(TRUE)
+    non_na_data <- aov_data[!is.na(col_vals), ]
+    for (gv in group_vars) {
+      if (length(unique(non_na_data[[gv]])) < 2) return(TRUE)
+    }
+    FALSE
+  }
+
   # First pass: collect all row names from group summaries
   for (col_name in colnames(aov_data)) {
     if (!is.numeric(aov_data[[col_name]]) || is.factor(aov_data[[col_name]])) next
-    
+
+    if (col_is_invariant(col_name)) {
+      invariant_cols <- c(invariant_cols, col_name)
+      next
+    }
+
     formula <- as.formula(paste(col_name, "~", paste(group_vars, collapse = "*")))
     t.anova <- aov(formula, data = aov_data)
     test2 <- agricolae::HSD.test(t.anova, trt = group_vars, group = TRUE)
-    
+
     row_names_list[[col_name]] <- rownames(test2$groups)
   }
   
@@ -261,7 +285,19 @@ aovInteractSummaryTable <- function(aov_data,
       raw_outputs[[col_name]] <- list(aov = t.anova, tukey = test2)
     }
   }
-  
+
+  # Populate invariant columns with "INVARIANT" for every row
+  n_rows <- length(row_labels)
+  for (col_name in invariant_cols) {
+    summary_list[[col_name]] <- rep("INVARIANT", n_rows)
+  }
+
+  # Restore original column order (non-invariant + invariant may be out of order)
+  all_numeric_cols <- colnames(aov_data)[
+    sapply(aov_data, is.numeric) & !sapply(aov_data, is.factor)
+  ]
+  summary_list <- summary_list[intersect(all_numeric_cols, names(summary_list))]
+
   # Create the summary table
   summary_table <- as.data.frame(summary_list, stringsAsFactors = FALSE)
   summary_table <- cbind(Type = row_labels, summary_table)

--- a/tests/testthat/test_aovInteractSummaryTable.R
+++ b/tests/testthat/test_aovInteractSummaryTable.R
@@ -40,3 +40,53 @@ test_that("aovInteractSummaryTable does not include Residuals rows", {
   expect_length(residual_rows, 0)
 })
 
+test_that("aovInteractSummaryTable handles constant-value (invariant) columns without error", {
+  greenhouse1_data <- greenhouse$greenhouse1
+  # Add a column that is completely constant
+  greenhouse1_data$constant_col <- 42.0
+
+  result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+
+  expect_s3_class(result, "data.frame")
+  expect_true("constant_col" %in% colnames(result))
+  # Every cell in that column should be "INVARIANT"
+  expect_true(all(result[["constant_col"]] == "INVARIANT"))
+})
+
+test_that("aovInteractSummaryTable handles columns present for only one factor level without error", {
+  greenhouse1_data <- greenhouse$greenhouse1
+  # Add a column with values only for the first variety level; NA for all others
+  first_variety <- levels(as.factor(greenhouse1_data$variety))[1]
+  greenhouse1_data$single_factor_col <- ifelse(
+    greenhouse1_data$variety == first_variety,
+    runif(nrow(greenhouse1_data)),
+    NA_real_
+  )
+
+  expect_no_error({
+    result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  })
+
+  result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  expect_true("single_factor_col" %in% colnames(result))
+  expect_true(all(result[["single_factor_col"]] == "INVARIANT"))
+})
+
+test_that("aovSummaryTable handles columns present for only one factor level without error", {
+  greenhouse1_data <- greenhouse$greenhouse1
+  first_variety <- levels(as.factor(greenhouse1_data$variety))[1]
+  greenhouse1_data$single_factor_col <- ifelse(
+    greenhouse1_data$variety == first_variety,
+    runif(nrow(greenhouse1_data)),
+    NA_real_
+  )
+
+  expect_no_error({
+    result <- aovSummaryTable(greenhouse1_data, group_var = "variety")
+  })
+
+  result <- aovSummaryTable(greenhouse1_data, group_var = "variety")
+  expect_true("single_factor_col" %in% colnames(result))
+  expect_true(all(result[["single_factor_col"]] == "invariant"))
+})
+


### PR DESCRIPTION
## Summary
This PR adds robust handling for invariant (constant-value) columns in both `aovSummaryTable` and `aovInteractSummaryTable` functions. Previously, these functions would fail when encountering columns with constant values or columns where a grouping variable had fewer than 2 levels after NA removal, which would cause ANOVA contrasts errors.

## Key Changes

- **Enhanced invariance detection in `aovSummaryTable`**: Added logic to detect columns that are either constant-valued OR have a grouping variable with fewer than 2 non-NA levels after filtering. Such columns are now marked as "invariant" instead of causing errors.

- **New helper function in `aovInteractSummaryTable`**: Introduced `col_is_invariant()` helper function that checks if a column should be skipped from ANOVA analysis due to:
  - Constant values (all identical)
  - Any grouping variable having fewer than 2 unique levels after NA removal

- **Early filtering of invariant columns**: Invariant columns are now identified and skipped during the first pass of `aovInteractSummaryTable`, preventing ANOVA computation errors before they occur.

- **Proper column ordering**: Added logic to restore the original column order in the output, ensuring invariant columns appear in their natural position rather than at the end.

- **Comprehensive test coverage**: Added three new test cases covering:
  - Constant-value columns in `aovInteractSummaryTable`
  - Single-factor-level columns in `aovInteractSummaryTable`
  - Single-factor-level columns in `aovSummaryTable`

## Implementation Details

The invariance check examines both the response variable (constant values) and the grouping variables (fewer than 2 levels after NA removal). This prevents the "contrasts can be applied only to factors with 2 or more levels" error that would otherwise occur during ANOVA computation.

https://claude.ai/code/session_011ji4oNEd9BdChUpoZGFqPs