### PR TITLE
Replace N/A with INVARIANT for invariant p-values in ANOVA

### DIFF
--- a/R/anova_summary.funct.R
+++ b/R/anova_summary.funct.R
@@ -319,8 +319,8 @@ aovInteractSummaryTable <- function(aov_data,
           bh_corr_row <- c(bh_corr_row, paste0(signif(bh_val, digits = 4), " ", stars.pval(bh_val)))
           bh_sig_row <- c(bh_sig_row, ifelse(bh_val <= 0.05, "SIGNIFICANT", "NOT SIGNIFICANT"))
         } else {
-          bh_corr_row <- c(bh_corr_row, "N/A")
-          bh_sig_row <- c(bh_sig_row, "N/A")
+          bh_corr_row <- c(bh_corr_row, "INVARIANT")
+          bh_sig_row <- c(bh_sig_row, "INVARIANT")
         }
       }
 


### PR DESCRIPTION
## Summary
Updated the ANOVA interaction summary table to use more descriptive terminology when reporting p-values for invariant factors.

## Changes
- Changed the placeholder text from "N/A" to "INVARIANT" in both the corrected p-value row and significance row when a p-value cannot be calculated (i.e., when the else condition is met in the Benjamini-Hochberg correction logic)
- This affects two output fields:
  - `bh_corr_row`: Now displays "INVARIANT" instead of "N/A"
  - `bh_sig_row`: Now displays "INVARIANT" instead of "N/A"

## Details
The change clarifies that factors with invariant (constant) values cannot have their statistical significance assessed, making the output more informative for users interpreting ANOVA results.

https://claude.ai/code/session_011qC6QcW7FYCjQHA17SVDMD