### PR TITLE
Remove mean from @importFrom stats in peakTableAlign.R

### DIFF
--- a/R/peakTableAlign.R
+++ b/R/peakTableAlign.R
@@ -228,7 +228,7 @@ read_agilent_dad_peaks <- function(
 #' )
 #' }
 #'
-#' @importFrom stats sd mean
+#' @importFrom stats sd
 #' @export
 align_peaks_by_rt <- function(peaks_long, max_drift = 0.5) {
 


### PR DESCRIPTION
stats::mean does not exist — mean() is a base function and does not need to be imported via @importFrom. Only sd is actually from stats. This eliminates the devtools::document() warning.

https://claude.ai/code/session_011qC6QcW7FYCjQHA17SVDMD