### PR TITLE
Fix en-dash encoding and improve cielab_swatch documentation

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:  # Allows manual re-runs from the Actions tab
 
 permissions:
   contents: read

--- a/R/cielab.funct.R
+++ b/R/cielab.funct.R
@@ -963,7 +963,7 @@ cielab_kinetics <- function(data,
       comparison_type = type,
       from_time = from_t,
       to_time = to_t,
-      contrast = paste(to_t, "–", from_t),
+      contrast = paste(to_t, "\u2013", from_t),
       n_from = r1$n,
       n_to = r2$n,
       dL = r2$L - r1$L,
@@ -1101,9 +1101,16 @@ cielab_kinetics <- function(data,
 #'   CIELab_a = c(50, -5, 20),
 #'   CIELab_b = c(30, 10, 15)
 #' )
-#' cielab_swatch(df, "swatches.png")
+#' # Write to a temporary file so the example leaves nothing behind.
+#' out_png <- file.path(tempdir(), "swatches.png")
+#' cielab_swatch(df, out_png)
+#' unlink(out_png)
+#'
+#' # PDF and SVG output work the same way (SVG needs the svglite package).
+#' \dontrun{
 #' cielab_swatch(df, "swatches.pdf")
 #' cielab_swatch(df, "swatches.svg")
+#' }
 #'
 #' @export
 cielab_swatch <- function(CIELab,

--- a/man/cielab_swatch.Rd
+++ b/man/cielab_swatch.Rd
@@ -61,8 +61,15 @@ df <- data.frame(
   CIELab_a = c(50, -5, 20),
   CIELab_b = c(30, 10, 15)
 )
-cielab_swatch(df, "swatches.png")
+# Write to a temporary file so the example leaves nothing behind.
+out_png <- file.path(tempdir(), "swatches.png")
+cielab_swatch(df, out_png)
+unlink(out_png)
+
+# PDF and SVG output work the same way (SVG needs the svglite package).
+\dontrun{
 cielab_swatch(df, "swatches.pdf")
 cielab_swatch(df, "swatches.svg")
+}
 
 }


### PR DESCRIPTION
## Summary
This PR makes three improvements to the codebase: fixes a character encoding issue in the kinetics function, improves the `cielab_swatch` function documentation with better examples, and enables manual workflow runs.

## Key Changes

- **Character encoding fix**: Changed the en-dash character in `cielab_kinetics` from a literal "–" to the Unicode escape sequence `\u2013` for better cross-platform compatibility and consistency.

- **Documentation improvements for `cielab_swatch`**:
  - Updated the example to write output to a temporary directory instead of the current working directory, ensuring the example doesn't leave files behind
  - Added cleanup code using `unlink()` to remove the temporary file after creation
  - Wrapped the PDF and SVG examples in `\dontrun{}` blocks since they require additional dependencies (svglite for SVG)
  - Added clarifying comments explaining the temporary file approach and optional output formats

- **CI/CD enhancement**: Added `workflow_dispatch` trigger to the GitHub Actions workflow, allowing manual re-runs from the Actions tab for better debugging and testing flexibility.

## Implementation Details

The documentation changes follow R package best practices by ensuring examples don't pollute the user's working directory and clearly indicate which examples require optional dependencies.

https://claude.ai/code/session_018q9CPfatfJqWu7U5XUiAGz