### PR TITLE
Fix silent all-NA CIELab failures, cryptic swatch crash, and wrong scan-resolution docs

### DIFF
--- a/R/cielab.funct.R
+++ b/R/cielab.funct.R
@@ -192,10 +192,15 @@ cielab_spectroscopy_percentage_to_fraction <- function(transmission_pct) {
 #' Following the OIV-MA-AS2-11 procedure, the calculation uses transmittance
 #' readings at 5 nm intervals from 380 to 780 nm (the wavelengths at which the
 #' method's Table 1 coefficients are defined). Readings at intermediate
-#' wavelengths - e.g. from instruments scanning at 1 or 2 nm resolution - are
+#' wavelengths - e.g. from an instrument scanning at 1 nm resolution - are
 #' discarded with a message. A sample must have a reading at every 5 nm grid
-#' wavelength, otherwise NA is returned with a warning. Replicate readings at
-#' the same wavelength (e.g. when grouping replicates by wine) are averaged.
+#' wavelength, otherwise NA is returned with a warning. Note that this means
+#' the scan interval must land on every multiple of 5 nm: a 2 nm scan
+#' starting from an even wavelength (300, 302, ... nm) never measures the
+#' odd grid wavelengths (385, 395, ... nm), so every sample returns NA.
+#' Set the spectrophotometer to a 5 nm (or 1 nm) interval covering
+#' 380-780 nm. Replicate readings at the same wavelength (e.g. when
+#' grouping replicates by wine) are averaged.
 #'
 #' @examples
 #' # Wide format example

--- a/R/cielab.funct.R
+++ b/R/cielab.funct.R
@@ -100,7 +100,8 @@ cielab_spectroscopy_percentage_to_fraction <- function(transmission_pct) {
   }, numeric(1))
 
   if (any(is.na(T10_on_grid))) {
-    return(list(L = NA, a = NA, b = NA, C = NA, H = NA))
+    return(list(L = NA_real_, a = NA_real_, b = NA_real_,
+                C = NA_real_, H = NA_real_))
   }
 
   # Calculate tristimulus values
@@ -306,6 +307,14 @@ cielab_from_spectrum <- function(data, sample_col = NULL, path_mm = 10) {
             "Use cielab_spectroscopy_percentage_to_fraction() to convert.")
   }
 
+  # Rows without a wavelength can never be matched to the OIV grid; keep them
+  # out so they don't turn into all-NA rows when subsetting below.
+  na_lambda <- is.na(data_long$lambda)
+  if (any(na_lambda)) {
+    warning("Removed ", sum(na_lambda), " reading(s) with missing wavelength.")
+    data_long <- data_long[!na_lambda, ]
+  }
+
   # The OIV-MA-AS2-11 method specifies transmittance readings every 5 nm from
   # 380 to 780 nm, and its Table 1 coefficients exist only at those
   # wavelengths. Keep readings on the 5 nm grid and discard any
@@ -325,6 +334,14 @@ cielab_from_spectrum <- function(data, sample_col = NULL, path_mm = 10) {
   # Process each sample
   samples <- unique(data_long$.sample_id)
   oiv_grid <- .oiv_coefficients$lambda
+  na_result <- function(s) {
+    data.frame(
+      .sample_id = s,
+      CIELab_L = NA_real_, CIELab_a = NA_real_, CIELab_b = NA_real_,
+      CIELab_C = NA_real_, CIELab_H = NA_real_,
+      stringsAsFactors = FALSE
+    )
+  }
   results <- lapply(samples, function(s) {
     subset_data <- data_long[data_long$.sample_id == s, ]
 
@@ -336,12 +353,21 @@ cielab_from_spectrum <- function(data, sample_col = NULL, path_mm = 10) {
               paste(head(missing_wl, 3), collapse = ", "),
               " nm); returning NA. OIV-MA-AS2-11 requires readings every ",
               "5 nm from 380 to 780 nm.")
-      return(data.frame(
-        .sample_id = s,
-        CIELab_L = NA, CIELab_a = NA, CIELab_b = NA,
-        CIELab_C = NA, CIELab_H = NA,
-        stringsAsFactors = FALSE
-      ))
+      return(na_result(s))
+    }
+
+    # A wavelength can be present but carry only NA transmittance readings;
+    # that would otherwise propagate to an NA result with no explanation.
+    na_wl <- vapply(oiv_grid, function(l) {
+      all(is.na(subset_data$T[subset_data$lambda == l]))
+    }, logical(1))
+    if (any(na_wl)) {
+      warning("Sample '", s, "' has NA transmittance at ", sum(na_wl),
+              " OIV grid wavelength(s) (e.g. ",
+              paste(head(oiv_grid[na_wl], 3), collapse = ", "),
+              " nm); returning NA. Check the source data for missing or ",
+              "non-numeric readings.")
+      return(na_result(s))
     }
 
     lab <- .cielab_single(subset_data$lambda, subset_data$T, path_mm)
@@ -359,6 +385,19 @@ cielab_from_spectrum <- function(data, sample_col = NULL, path_mm = 10) {
 
   result <- do.call(rbind, results)
 
+  # Individual per-sample warnings are easy to miss (R suppresses output after
+  # 50 warnings), so summarise failures loudly. A single sample already gets a
+  # specific warning above.
+  n_failed <- sum(is.na(result$CIELab_L))
+  if (nrow(result) > 1 && n_failed == nrow(result)) {
+    warning("All ", nrow(result), " samples returned NA CIELab values. ",
+            "Run warnings() to see the per-sample reasons (usually missing ",
+            "OIV grid wavelengths or NA transmittance readings).")
+  } else if (n_failed > 0 && n_failed < nrow(result)) {
+    warning(n_failed, " of ", nrow(result), " samples returned NA CIELab ",
+            "values. Run warnings() to see the per-sample reasons.")
+  }
+
   # Rename sample column back to original name
   names(result)[names(result) == ".sample_id"] <- sample_col
 
@@ -368,6 +407,30 @@ cielab_from_spectrum <- function(data, sample_col = NULL, path_mm = 10) {
 # ==============================================================================
 # Colour Difference Functions
 # ==============================================================================
+
+# Internal: validate that `data` has CIELab coordinate columns and drop rows
+# where any coordinate is NA (e.g. samples cielab_from_spectrum() could not
+# compute), so they don't silently turn every group mean into NA.
+.drop_na_lab <- function(data, fn_name) {
+  lab_cols <- c("CIELab_L", "CIELab_a", "CIELab_b")
+  missing_cols <- setdiff(lab_cols, names(data))
+  if (length(missing_cols) > 0) {
+    stop("Missing required columns: ", paste(missing_cols, collapse = ", "))
+  }
+  na_rows <- is.na(data$CIELab_L) | is.na(data$CIELab_a) | is.na(data$CIELab_b)
+  if (all(na_rows)) {
+    stop("All rows have NA CIELab values, so ", fn_name, "() has nothing to ",
+         "compare. This usually means cielab_from_spectrum() could not ",
+         "compute colours - run warnings() after calling it to see the ",
+         "per-sample reasons.")
+  }
+  if (any(na_rows)) {
+    warning("Dropping ", sum(na_rows), " of ", nrow(data), " row(s) with NA ",
+            "CIELab values before computing colour differences.")
+    data <- data[!na_rows, ]
+  }
+  data
+}
 
 #' Calculate chroma from CIELab a* and b* values
 #'
@@ -533,7 +596,8 @@ deltaE94 <- function(L1, a1, b1, L2, a2, b2) {
 #' @param b Numeric b* value(s)
 #' @param fixup Logical; if TRUE (default), colours outside the sRGB gamut are
 #'   clipped to the nearest representable colour rather than returned as NA.
-#' @return Character vector of hex colour strings (e.g. "#A03C2F").
+#' @return Character vector of hex colour strings (e.g. "#A03C2F"). Missing
+#'   coordinates give NA.
 #'
 #' @details Requires the \pkg{colorspace} package.
 #'
@@ -548,6 +612,17 @@ cielab_to_hex <- function(L, a, b, fixup = TRUE) {
   if (!requireNamespace("colorspace", quietly = TRUE)) {
     stop("Package 'colorspace' is required. Install with: install.packages('colorspace')")
   }
+  # An all-NA column is logical, which colorspace::LAB() rejects with the
+  # unhelpful "invalid color matrix"; coerce so NA coordinates give NA hex.
+  check_num <- function(x, name) {
+    if (!is.numeric(x) && !all(is.na(x))) {
+      stop("'", name, "' must be numeric, got ", class(x)[1])
+    }
+    as.double(x)
+  }
+  L <- check_num(L, "L")
+  a <- check_num(a, "a")
+  b <- check_num(b, "b")
   colorspace::hex(colorspace::LAB(L, a, b), fixup = fixup)
 }
 
@@ -586,6 +661,10 @@ cielab_to_hex <- function(L, a, b, fixup = TRUE) {
 #' This approach is robust to outliers and gives a single summary value
 #' per comparison.
 #'
+#' Rows with NA CIELab coordinates (e.g. samples that
+#' \code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+#' warning before centroids are calculated.
+#'
 #' The function requires the \pkg{farver} package for CIE2000 calculations.
 #'
 #' @examples
@@ -618,6 +697,7 @@ calc_colour_diff <- function(data,
   if (!compare_by %in% names(data)) {
     stop("Column '", compare_by, "' not found in data")
   }
+  data <- .drop_na_lab(data, "calc_colour_diff")
   if (!reference_level %in% data[[compare_by]]) {
     stop("Reference level '", reference_level, "' not found in column '",
          compare_by, "'")
@@ -729,6 +809,10 @@ calc_colour_diff <- function(data,
 #' useful when you need confidence intervals or want to assess the spread
 #' of colour differences.
 #'
+#' Rows with NA CIELab coordinates (e.g. samples that
+#' \code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+#' warning before pairwise differences are calculated.
+#'
 #' The function requires the \pkg{farver} package for CIE2000 calculations.
 #'
 #' @examples
@@ -770,6 +854,7 @@ calc_pairwise_dE <- function(data,
   if (!compare_by %in% names(data)) {
     stop("Column '", compare_by, "' not found in data")
   }
+  data <- .drop_na_lab(data, "calc_pairwise_dE")
   if (!reference_level %in% data[[compare_by]]) {
     stop("Reference level '", reference_level, "' not found in column '",
          compare_by, "'")
@@ -889,6 +974,10 @@ calc_pairwise_dE <- function(data,
 #' from the start, \code{"consecutive"} to see the rate of change between
 #' successive measurements, or \code{"both"} for the two stacked together.
 #'
+#' Rows with NA CIELab coordinates (e.g. samples that
+#' \code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+#' warning before centroids are calculated.
+#'
 #' The function requires the \pkg{farver} package for CIE2000 calculations.
 #'
 #' @seealso \code{\link{calc_colour_diff}}, \code{\link{deltaE00}}
@@ -921,6 +1010,7 @@ cielab_kinetics <- function(data,
   if (length(missing_cols) > 0) {
     stop("Missing required columns: ", paste(missing_cols, collapse = ", "))
   }
+  data <- .drop_na_lab(data, "cielab_kinetics")
 
   # Determine the chronological order of the timepoints.
   ordered_times <- .order_timepoints(data[[time_col]], time_levels)
@@ -1094,6 +1184,10 @@ cielab_kinetics <- function(data,
 #'   \item SVG: Web-friendly vector format (requires svglite package)
 #' }
 #'
+#' Rows with NA CIELab coordinates (e.g. samples that
+#' \code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+#' warning; if every row is NA an error explains where to look.
+#'
 #' @examples
 #' df <- data.frame(
 #'   WineName = c("Red", "White", "Rose"),
@@ -1142,6 +1236,22 @@ cielab_swatch <- function(CIELab,
   missing_cols <- setdiff(required_cols, names(CIELab))
   if (length(missing_cols) > 0) {
     stop("Missing required columns: ", paste(missing_cols, collapse = ", "))
+  }
+
+  # Samples with NA coordinates (e.g. cielab_from_spectrum() failures) cannot
+  # be drawn; drop them with an explanation rather than crash downstream.
+  na_rows <- is.na(CIELab$CIELab_L) | is.na(CIELab$CIELab_a) |
+    is.na(CIELab$CIELab_b)
+  if (all(na_rows)) {
+    stop("All rows have NA CIELab values, so no swatches can be drawn. ",
+         "This usually means cielab_from_spectrum() could not compute colours ",
+         "- run warnings() after calling it to see the per-sample reasons.")
+  }
+  if (any(na_rows)) {
+    warning("Dropping ", sum(na_rows), " row(s) with NA CIELab values: ",
+            paste(head(CIELab$WineName[na_rows], 5), collapse = ", "),
+            if (sum(na_rows) > 5) ", ..." else "")
+    CIELab <- CIELab[!na_rows, ]
   }
 
   n <- nrow(CIELab)

--- a/man/calc_colour_diff.Rd
+++ b/man/calc_colour_diff.Rd
@@ -50,6 +50,10 @@ conditions by reducing multiple observations to their centroids first.
 This approach is robust to outliers and gives a single summary value
 per comparison.
 
+Rows with NA CIELab coordinates (e.g. samples that
+\code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+warning before centroids are calculated.
+
 The function requires the \pkg{farver} package for CIE2000 calculations.
 }
 \examples{

--- a/man/calc_pairwise_dE.Rd
+++ b/man/calc_pairwise_dE.Rd
@@ -55,6 +55,10 @@ This approach captures the full variability in colour differences and is
 useful when you need confidence intervals or want to assess the spread
 of colour differences.
 
+Rows with NA CIELab coordinates (e.g. samples that
+\code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+warning before pairwise differences are calculated.
+
 The function requires the \pkg{farver} package for CIE2000 calculations.
 }
 \examples{

--- a/man/cielab_from_spectrum.Rd
+++ b/man/cielab_from_spectrum.Rd
@@ -58,10 +58,15 @@ significantly > 1 (> 1.1) trigger a warning - use
 Following the OIV-MA-AS2-11 procedure, the calculation uses transmittance
 readings at 5 nm intervals from 380 to 780 nm (the wavelengths at which the
 method's Table 1 coefficients are defined). Readings at intermediate
-wavelengths - e.g. from instruments scanning at 1 or 2 nm resolution - are
+wavelengths - e.g. from an instrument scanning at 1 nm resolution - are
 discarded with a message. A sample must have a reading at every 5 nm grid
-wavelength, otherwise NA is returned with a warning. Replicate readings at
-the same wavelength (e.g. when grouping replicates by wine) are averaged.
+wavelength, otherwise NA is returned with a warning. Note that this means
+the scan interval must land on every multiple of 5 nm: a 2 nm scan
+starting from an even wavelength (300, 302, ... nm) never measures the
+odd grid wavelengths (385, 395, ... nm), so every sample returns NA.
+Set the spectrophotometer to a 5 nm (or 1 nm) interval covering
+380-780 nm. Replicate readings at the same wavelength (e.g. when
+grouping replicates by wine) are averaged.
 }
 \examples{
 # Wide format example

--- a/man/cielab_kinetics.Rd
+++ b/man/cielab_kinetics.Rd
@@ -30,27 +30,27 @@ or \code{"consecutive"} (each timepoint vs the previous one).}
 
 \item{time_levels}{Optional character/numeric vector giving the timepoints
 in chronological order. If NULL (default), the order is taken from: the
-numeric values (if \code{time_col} is numeric); the levels of an ordered
-factor; otherwise a number parsed from each label (e.g. "0M", "3M", "12M"
--> 0, 3, 12), falling back to factor levels or order of appearance with a
-message if no number can be parsed.}
+numeric values (if \code{time_col} is numeric); the factor levels (if
+\code{time_col} is a factor); otherwise a number parsed from each label
+(e.g. "0M", "3M", "12M" -> 0, 3, 12), falling back to order of appearance
+with a message if no number can be parsed.}
 }
 \value{
 A data.frame with one row per comparison, containing:
-\describe{
-  \item{<group_by columns>}{Grouping variables (if specified)}
-  \item{comparison_type}{"baseline" or "consecutive"}
-  \item{from_time, to_time}{The two timepoints compared}
-  \item{contrast}{Character label, e.g. "3M - 0M"}
-  \item{n_from, n_to}{Number of observations averaged at each timepoint}
-  \item{dL}{Difference in L* (lightness)}
-  \item{dC}{Difference in C* (chroma)}
-  \item{dh}{Signed difference in hue angle (degrees)}
-  \item{dE76}{CIE76 Delta E between the two centroids}
-  \item{dE00}{CIE2000 Delta E between the two centroids}
-}
-Differences are expressed as (later timepoint - earlier timepoint), so a
-positive \code{dL} means the wine got lighter over time.
+  \describe{
+    \item{<group_by columns>}{Grouping variables (if specified)}
+    \item{comparison_type}{"baseline" or "consecutive"}
+    \item{from_time, to_time}{The two timepoints compared}
+    \item{contrast}{Character label, e.g. "3M - 0M"}
+    \item{n_from, n_to}{Number of observations averaged at each timepoint}
+    \item{dL}{Difference in L* (lightness)}
+    \item{dC}{Difference in C* (chroma)}
+    \item{dh}{Signed difference in hue angle (degrees)}
+    \item{dE76}{CIE76 Delta E between the two centroids}
+    \item{dE00}{CIE2000 Delta E between the two centroids}
+  }
+  Differences are expressed as (later timepoint - earlier timepoint), so a
+  positive \code{dL} means the wine got lighter over time.
 }
 \description{
 Tracks how wine colour changes across an ordered series of timepoints by
@@ -67,6 +67,10 @@ of timepoints. Use \code{comparison = "baseline"} to see cumulative change
 from the start, \code{"consecutive"} to see the rate of change between
 successive measurements, or \code{"both"} for the two stacked together.
 
+Rows with NA CIELab coordinates (e.g. samples that
+\code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+warning before centroids are calculated.
+
 The function requires the \pkg{farver} package for CIE2000 calculations.
 }
 \examples{
@@ -81,6 +85,7 @@ kin <- cielab_kinetics(
 # Only cumulative change from the first timepoint
 kin <- cielab_kinetics(wine_colours, "Months", comparison = "baseline")
 }
+
 }
 \seealso{
 \code{\link{calc_colour_diff}}, \code{\link{deltaE00}}

--- a/man/cielab_swatch.Rd
+++ b/man/cielab_swatch.Rd
@@ -53,6 +53,10 @@ Supported output formats depend on your system's graphics devices:
   \item PDF, EPS, PS: Vector formats (scalable)
   \item SVG: Web-friendly vector format (requires svglite package)
 }
+
+Rows with NA CIELab coordinates (e.g. samples that
+\code{\link{cielab_from_spectrum}} could not compute) are dropped with a
+warning; if every row is NA an error explains where to look.
 }
 \examples{
 df <- data.frame(

--- a/man/cielab_to_hex.Rd
+++ b/man/cielab_to_hex.Rd
@@ -17,7 +17,8 @@ cielab_to_hex(L, a, b, fixup = TRUE)
 clipped to the nearest representable colour rather than returned as NA.}
 }
 \value{
-Character vector of hex colour strings (e.g. "#A03C2F").
+Character vector of hex colour strings (e.g. "#A03C2F"). Missing
+  coordinates give NA.
 }
 \description{
 Converts CIELab L*, a*, b* coordinates to hexadecimal sRGB colour strings,
@@ -31,4 +32,5 @@ Requires the \pkg{colorspace} package.
 cielab_to_hex(50, 40, 30)
 cielab_to_hex(c(30, 90), c(50, -5), c(30, 10))
 }
+
 }

--- a/tests/testthat/test_cielab.R
+++ b/tests/testthat/test_cielab.R
@@ -485,6 +485,35 @@ test_that("colour difference functions drop NA rows with a warning", {
   )
 })
 
+test_that("full pipeline handles a 5 nm instrument scan end to end", {
+  # Simulates a spectrophotometer set to a 5 nm interval over 300-800 nm:
+  # 13 header lines, WL.nm. / X.T columns, percent transmission. This is the
+  # scan setting the OIV grid requires, so it must work with no warnings.
+  scan_dir <- file.path(tempdir(), "scan5nm_test")
+  dir.create(scan_dir, showWarnings = FALSE)
+  on.exit(unlink(scan_dir, recursive = TRUE), add = TRUE)
+
+  wl <- seq(300, 800, by = 5)
+  for (nm in c("Wine_A_1", "Wine_B_1")) {
+    trans_pct <- 100 * pmin(1, 0.05 + 0.9 * (wl - 300) / 500)
+    writeLines(
+      c(rep("instrument header", 13), "WL.nm.,X.T",
+        paste(wl, round(trans_pct, 3), sep = ",")),
+      file.path(scan_dir, paste0(nm, ".csv"))
+    )
+  }
+
+  suppressMessages(spectra <- process_spectrum(scan_dir, skip = 13))
+  expect_equal(sort(unique(spectra$sample_name)), c("Wine_A_1", "Wine_B_1"))
+
+  expect_no_warning(
+    result <- cielab_from_spectrum(spectra, sample_col = "sample_name")
+  )
+  expect_equal(nrow(result), 2)
+  expect_false(any(is.na(result$CIELab_L)))
+  expect_true(all(result$CIELab_L >= 0 & result$CIELab_L <= 100))
+})
+
 test_that("cielab_from_spectrum warns on percentage values", {
   wine_data <- generate_wine_spectra()
   # Convert to percentages (0-100)

--- a/tests/testthat/test_cielab.R
+++ b/tests/testthat/test_cielab.R
@@ -366,6 +366,125 @@ test_that("calc_colour_diff and calc_pairwise_dE validate the reference level", 
   )
 })
 
+test_that("cielab_from_spectrum warns on NA transmittance instead of silent NA", {
+  wine_data <- generate_wine_spectra()
+  wine_data <- wine_data[wine_data$WineName == "RedWine", ]
+  # Wavelength present, but its only reading is NA
+  wine_data$T[wine_data$lambda == 550] <- NA
+
+  expect_warning(
+    result <- cielab_from_spectrum(wine_data, sample_col = "WineName"),
+    "NA transmittance"
+  )
+  expect_true(is.na(result$CIELab_L))
+})
+
+test_that("cielab_from_spectrum failure paths return numeric (not logical) NA", {
+  wine_data <- generate_wine_spectra()
+  gappy <- wine_data[wine_data$lambda != 550, ]
+
+  result <- suppressWarnings(
+    cielab_from_spectrum(gappy, sample_col = "WineName")
+  )
+  # All samples fail, but the CIELab columns must stay numeric so downstream
+  # functions (colorspace, dplyr summaries) see doubles, not logicals
+  expect_true(all(is.na(result$CIELab_L)))
+  for (col in c("CIELab_L", "CIELab_a", "CIELab_b", "CIELab_C", "CIELab_H")) {
+    expect_type(result[[col]], "double")
+  }
+})
+
+test_that("cielab_from_spectrum summarises how many samples failed", {
+  wine_data <- generate_wine_spectra()
+
+  # All samples missing a grid wavelength -> loud "All ... samples" summary
+  gappy_all <- wine_data[wine_data$lambda != 550, ]
+  w <- capture_warnings(cielab_from_spectrum(gappy_all, sample_col = "WineName"))
+  expect_true(any(grepl("All 3 samples returned NA", w)))
+
+  # One sample missing a wavelength -> "1 of 3 samples" summary
+  gappy_one <- wine_data[!(wine_data$WineName == "RedWine" &
+                             wine_data$lambda == 550), ]
+  w <- capture_warnings(cielab_from_spectrum(gappy_one, sample_col = "WineName"))
+  expect_true(any(grepl("1 of 3 samples returned NA", w)))
+})
+
+test_that("cielab_to_hex handles NA coordinates without crashing", {
+  skip_if_not_installed("colorspace")
+
+  # Logical NA (what an all-failed cielab_from_spectrum result used to give)
+  expect_true(is.na(cielab_to_hex(NA, NA, NA)))
+
+  # Mixed valid / NA values
+  result <- cielab_to_hex(c(50, NA), c(10, NA), c(20, NA))
+  expect_false(is.na(result[1]))
+  expect_true(is.na(result[2]))
+
+  # Non-numeric input gets a clear error
+  expect_error(cielab_to_hex("fifty", 10, 20), "must be numeric")
+})
+
+test_that("cielab_swatch explains NA CIELab values instead of CheckMatrix error", {
+  skip_if_not_installed("ggplot2")
+  skip_if_not_installed("colorspace")
+
+  all_na <- data.frame(
+    WineName = c("A", "B"),
+    CIELab_L = NA, CIELab_a = NA, CIELab_b = NA
+  )
+  expect_error(
+    cielab_swatch(all_na, file.path(tempdir(), "na_swatch.png")),
+    "All rows have NA CIELab values"
+  )
+
+  some_na <- data.frame(
+    WineName = c("Good", "Bad"),
+    CIELab_L = c(50, NA),
+    CIELab_a = c(10, NA),
+    CIELab_b = c(20, NA)
+  )
+  out_png <- file.path(tempdir(), "partial_swatch.png")
+  expect_warning(
+    cielab_swatch(some_na, out_png),
+    "Dropping 1 row\\(s\\) with NA CIELab values: Bad"
+  )
+  expect_true(file.exists(out_png))
+  unlink(out_png)
+})
+
+test_that("colour difference functions drop NA rows with a warning", {
+  lab_data <- data.frame(
+    EtOH = rep(c("CTRL", "T1"), each = 3),
+    CIELab_L = c(50, 52, NA, 60, 61, 59),
+    CIELab_a = c(10, 11, NA, 15, 14, 16),
+    CIELab_b = c(5, 6, NA, 8, 7, 9)
+  )
+
+  expect_warning(
+    diffs <- calc_colour_diff(lab_data),
+    "Dropping 1 of 6"
+  )
+  expect_false(any(is.na(diffs$dE76_cent)))
+
+  expect_warning(
+    pw <- calc_pairwise_dE(lab_data),
+    "Dropping 1 of 6"
+  )
+  expect_false(any(is.na(pw$dE_mean)))
+
+  # All-NA data gets an informative error, not an all-NA result
+  all_na <- lab_data
+  all_na[c("CIELab_L", "CIELab_a", "CIELab_b")] <- NA
+  expect_error(
+    calc_colour_diff(all_na),
+    "All rows have NA CIELab values"
+  )
+  expect_error(
+    calc_pairwise_dE(all_na),
+    "All rows have NA CIELab values"
+  )
+})
+
 test_that("cielab_from_spectrum warns on percentage values", {
   wine_data <- generate_wine_spectra()
   # Convert to percentages (0-100)


### PR DESCRIPTION
## Summary

Running the CIELab pipeline on real spectrophotometer data produced all-NA results with no visible explanation, and `cielab_swatch()` crashed with colorspace's cryptic `CheckMatrix(coords): invalid color matrix`. Root cause: the data was scanned at a 2 nm interval, which can never supply the odd OIV grid wavelengths (385, 395, ... nm), so every sample failed — and the failures were silent, wrongly typed, and poisoned everything downstream. The docs also incorrectly claimed 2 nm scans were handled.

## Changes

- **`cielab_from_spectrum()`**: failure paths return `NA_real_` instead of logical `NA` so CIELab columns stay numeric; samples with NA transmittance at a grid wavelength now warn (previously completely silent); a loud summary warning fires when some or all samples return NA (per-sample warnings get suppressed by R past 50); rows with missing wavelengths are dropped instead of becoming phantom all-NA rows.
- **`cielab_to_hex()`**: coerces logical-NA input, gives NA hex for NA coordinates, and rejects non-numeric input with a clear message instead of the `CheckMatrix` error.
- **`cielab_swatch()`**: drops NA rows with a warning naming the affected samples; errors informatively when every row is NA.
- **`calc_colour_diff()`, `calc_pairwise_dE()`, `cielab_kinetics()`**: drop NA CIELab rows with a warning so one failed sample no longer turns every group mean into NA; error informatively when all rows are NA.
- **Docs**: corrected the claim that 1 or 2 nm scans are handled — only intervals landing on every multiple of 5 nm work (5 nm or 1 nm); a 2 nm scan from an even start wavelength always returns NA.
- **Tests**: regression tests for all of the above plus an end-to-end test running instrument-style 5 nm CSVs (13 header lines, `WL.nm.`/`X.T` columns, percent transmission) through `process_spectrum()` → `cielab_from_spectrum()`. Suite now at 85 tests.

## Test plan

- `tests/testthat/test_cielab.R`: 85 passed, 0 failed
- `tests/testthat/test_kinetics.R`: 30 passed, 0 failed
- `tests/testthat/test_peakAlign.R`: 42 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018P9yMYmbziyvHzFQWeqntn

---
_Generated by [Claude Code](https://claude.ai/code/session_018P9yMYmbziyvHzFQWeqntn)_