### PR TITLE
Tolerate instrument noise slightly above 100% transmission

### DIFF
--- a/R/cielab.funct.R
+++ b/R/cielab.funct.R
@@ -34,6 +34,11 @@
 #' Converts spectrophotometry transmission data from percentage (0-100) to
 #' fraction (0-1) format required by cielab_from_spectrum().
 #'
+#' Readings slightly above 100\% (e.g. 100.8\%) are normal instrument noise
+#' around a fully transparent blank and are converted without complaint.
+#' Values above 110\% suggest a real data problem and trigger a warning, as
+#' do negative values.
+#'
 #' @param transmission_pct Numeric vector of transmission values as percentages
 #'   (0-100 scale)
 #' @return Numeric vector of transmission values as fractions (0-1 scale)
@@ -52,8 +57,14 @@ cielab_spectroscopy_percentage_to_fraction <- function(transmission_pct) {
   if (any(transmission_pct < 0, na.rm = TRUE)) {
     warning("Negative transmission values detected; these are physically impossible.")
   }
-  if (any(transmission_pct > 100, na.rm = TRUE)) {
-    warning("Transmission values > 100% detected; check data for errors.")
+  # Readings a little over 100% are routine instrument noise around a fully
+  # transparent blank; only values well beyond that indicate a data problem.
+  # 110% mirrors the 1.1 fraction tolerance used in cielab_from_spectrum().
+  if (any(transmission_pct > 110, na.rm = TRUE)) {
+    warning("Transmission values > 110% detected (max = ",
+            round(max(transmission_pct, na.rm = TRUE), 1),
+            "%); readings slightly above 100% are normal instrument noise, ",
+            "but this is beyond that - check data for errors.")
   }
   transmission_pct / 100
 }

--- a/man/cielab_spectroscopy_percentage_to_fraction.Rd
+++ b/man/cielab_spectroscopy_percentage_to_fraction.Rd
@@ -17,6 +17,12 @@ Numeric vector of transmission values as fractions (0-1 scale)
 Converts spectrophotometry transmission data from percentage (0-100) to
 fraction (0-1) format required by cielab_from_spectrum().
 }
+\details{
+Readings slightly above 100\% (e.g. 100.8\%) are normal instrument noise
+around a fully transparent blank and are converted without complaint.
+Values above 110\% suggest a real data problem and trigger a warning, as
+do negative values.
+}
 \examples{
 # Convert 50\% transmission to fraction
 cielab_spectroscopy_percentage_to_fraction(50)

--- a/tests/testthat/test_cielab.R
+++ b/tests/testthat/test_cielab.R
@@ -70,10 +70,14 @@ test_that("cielab_spectroscopy_percentage_to_fraction warns on invalid values", 
     "Negative transmission values"
   )
 
-  # Values > 100 warning
+  # Slightly > 100% is normal instrument noise around a transparent blank
+  expect_no_warning(cielab_spectroscopy_percentage_to_fraction(100.8))
+  expect_equal(cielab_spectroscopy_percentage_to_fraction(100.8), 1.008)
+
+  # Values well above 100% still warn
   expect_warning(
-    cielab_spectroscopy_percentage_to_fraction(105),
-    "Transmission values > 100%"
+    cielab_spectroscopy_percentage_to_fraction(115),
+    "Transmission values > 110%"
   )
 })
 


### PR DESCRIPTION
## Summary

`cielab_spectroscopy_percentage_to_fraction()` warned on any transmission value over 100%, but readings like 100.8% are routine spectrophotometer noise around a fully transparent blank — real datasets produced dozens of spurious "check data for errors" warnings that drowned out meaningful ones.

## Changes

- Warn only above **110%**, mirroring the 1.1 fraction tolerance `cielab_from_spectrum()` already uses; values in the 100–110% range are converted silently and unmodified (100.8% → 1.008, nothing is clipped).
- The warning now reports the maximum value seen, so a genuine trigger is immediately interpretable.
- Docs updated to state the tolerance; tests updated (100.8% must be silent, 115% must warn) — suite at 87 passing.

## Test plan

- `tests/testthat/test_cielab.R`: 87 passed, 0 failed, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018P9yMYmbziyvHzFQWeqntn

---
_Generated by [Claude Code](https://claude.ai/code/session_018P9yMYmbziyvHzFQWeqntn)_