### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PenguinoidRTools
 Type: Package
 Title: PenguinoidRTools: Misc Useful R Functions
-Version: 0.7
+Version: 0.7.1
 Author: Gavin Duley <gduley@gmail.com>
 Maintainer: Gavin Duley <gduley@gmail.com>
 Description: This package contains useful R functions for statistical analysis


### PR DESCRIPTION
## Summary

The version number stayed at 0.7 across several behavioural fixes (PRs #22, #23), which made it impossible to tell from `packageVersion()` whether an installed copy included them, and let install tools skip updates thinking nothing had changed.

## Changes

- `DESCRIPTION`: Version 0.7 → 0.7.1. No code changes.

After merging, `packageVersion("PenguinoidRTools") == "0.7.1"` is a definitive check that the installed copy includes all fixes from #22 and #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018P9yMYmbziyvHzFQWeqntn

---
_Generated by [Claude Code](https://claude.ai/code/session_018P9yMYmbziyvHzFQWeqntn)_