### PR TITLE
Warn about unanalysable columns and require 2 residual df for Tukey

### DIFF
--- a/R/anova_summary.funct.R
+++ b/R/anova_summary.funct.R
@@ -3,6 +3,23 @@
 # Copyright (c) 2024 onwards, Gavin Duley
 # Licenced under the GPL-3.0 licence
 
+# Internal helper: warn about columns that were skipped so the reason is
+# visible in the console as well as in the summary table. skip_labels is a
+# named character vector of column name -> skip label.
+warn_skipped_columns <- function(skip_labels) {
+  if (length(skip_labels) == 0) return(invisible(NULL))
+  warning(
+    "The following columns could not be analysed and were filled with a ",
+    "label instead: ",
+    paste0(names(skip_labels), " (", skip_labels, ")", collapse = ", "),
+    ". They may be invariant or contain too many missing values - please ",
+    "check them, and consider removing them from the dataset prior to ",
+    "analysis.",
+    call. = FALSE
+  )
+  invisible(NULL)
+}
+
 # aovSummaryTable -------------------------------------------------------------
 
 #' AoV summary table
@@ -13,10 +30,12 @@
 #'  columns (other than the grouping variable) are ignored. Missing values are
 #'  allowed: observations with an NA in a given variable are dropped for that
 #'  variable's ANOVA only, and group means are computed over the observed
-#'  values. Columns that cannot be analysed are filled with a label instead:
-#'  "invariant" (constant, all NA, or fewer than two groups observed) or
-#'  "insufficient data" (too few non-NA observations to estimate an error
-#'  term). It also
+#'  values. Columns that cannot be analysed are filled with a label instead,
+#'  and a warning lists them: "invariant" (constant, all NA, or fewer than
+#'  two groups observed), "insufficient data" (fewer than two residual
+#'  degrees of freedom left after removing NAs, the minimum Tukey's test can
+#'  handle), or "not analysable" (the model or Tukey test failed for another
+#'  reason). It also
 #'  appends rows for the Benjamini–Hochberg (BH) corrected p-values and significance.
 #'  The output includes a “Type” column so that the row labels are exported to Excel.
 #'
@@ -57,16 +76,16 @@ aovSummaryTable <- function(aov_data,
   # rows with. "invariant": the response is constant or all NA (NAs don't
   # count as a distinct value), or group_var has <2 levels after removing NAs
   # for that column (which would cause the "contrasts" error).
-  # "insufficient data": so few non-NA observations remain that the ANOVA has
-  # zero residual degrees of freedom (e.g. one observation per group), which
-  # makes HSD.test fail on NaN p-values.
+  # "insufficient data": fewer than two residual degrees of freedom remain
+  # after removing NAs. Two is the minimum HSD.test can handle: R's
+  # qtukey/ptukey return NaN for df < 2, which crashes HSD.test.
   col_skip_label <- function(col_name) {
     col_vals <- aov_data[[col_name]]
     if (length(unique(col_vals[!is.na(col_vals)])) <= 1) return("invariant")
     non_na_groups <- aov_data[[group_var]][!is.na(col_vals)]
     n_groups <- length(unique(non_na_groups))
     if (n_groups < 2) return("invariant")
-    if (length(non_na_groups) - n_groups < 1) return("insufficient data")
+    if (length(non_na_groups) - n_groups < 2) return("insufficient data")
     NA_character_
   }
 
@@ -86,12 +105,27 @@ aovSummaryTable <- function(aov_data,
     # Run ANOVA and Tukey HSD. Backticks allow non-syntactic column names.
     # na.omit is set explicitly (rather than relying on the session's
     # na.action option) so rows with an NA in this column are dropped for
-    # this column's ANOVA only.
-    formula <- as.formula(paste0("`", columnname, "` ~ `", group_var, "`"))
-    t.anova <- aov(formula, data = aov_data, na.action = na.omit)
-    test2 <- agricolae::HSD.test(t.anova, trt = group_var, group = TRUE)
+    # this column's ANOVA only. If the model or Tukey test still fails on
+    # degenerate data despite the checks above, skip the column with a
+    # warning naming it rather than failing the whole table.
+    fit <- tryCatch({
+      formula <- as.formula(paste0("`", columnname, "` ~ `", group_var, "`"))
+      t.anova <- aov(formula, data = aov_data, na.action = na.omit)
+      test2 <- agricolae::HSD.test(t.anova, trt = group_var, group = TRUE)
+      list(aov = t.anova, tukey = test2)
+    }, error = function(e) e)
 
-    raw_outputs[[columnname]] <- list(aov = t.anova, tukey = test2)
+    if (inherits(fit, "error")) {
+      warning("Column '", columnname, "' could not be analysed: ",
+              conditionMessage(fit), call. = FALSE)
+      skip_labels[columnname] <- "not analysable"
+      summary_table[[columnname]] <- rep("not analysable", length(base_rows))
+      next
+    }
+    t.anova <- fit$aov
+    test2 <- fit$tukey
+
+    raw_outputs[[columnname]] <- fit
 
     # Build group summaries matching the factor levels.
     group_summaries <- rep("Not available", length(group_levels))
@@ -143,15 +177,17 @@ aovSummaryTable <- function(aov_data,
   }
   summary_table <- rbind(summary_table, bh_rows)
 
+  warn_skipped_columns(skip_labels)
+
   # Write the table to Excel (the "Type" column is now included).
   if (!is.null(output_file)) {
     openxlsx::write.xlsx(summary_table, output_file, rowNames = FALSE)
   }
-  
+
   if (return_raw) {
     assign(output_name, raw_outputs, envir = .GlobalEnv)
   }
-  
+
   return(summary_table)
 }
 
@@ -165,9 +201,11 @@ aovSummaryTable <- function(aov_data,
 #'  Missing values are allowed: observations with an NA in a given variable are
 #'  dropped for that variable's ANOVA only, and group means are computed over
 #'  the observed values. Columns that cannot be analysed are filled with a
-#'  label instead: "INVARIANT" (constant, all NA, or fewer than two levels of
-#'  a grouping variable observed) or "INSUFFICIENT DATA" (too few non-NA
-#'  observations to estimate an error term).
+#'  label instead, and a warning lists them: "INVARIANT" (constant, all NA,
+#'  or fewer than two levels of a grouping variable observed),
+#'  "INSUFFICIENT DATA" (fewer than two residual degrees of freedom left
+#'  after removing NAs, the minimum Tukey's test can handle), or
+#'  "NOT ANALYSABLE" (the model or Tukey test failed for another reason).
 #'  It also appends BH-corrected p-values and significance as additional rows.
 #'  The BH correction is applied separately within each effect family (i.e. all
 #'  p-values for a given main effect or interaction are corrected together,
@@ -202,9 +240,9 @@ aovInteractSummaryTable <- function(aov_data,
   # rows with. "INVARIANT": the response is constant or all NA (NAs don't
   # count as a distinct value), or any group_var has <2 levels after removing
   # NAs for that column (which would cause the "contrasts" error).
-  # "INSUFFICIENT DATA": so few non-NA observations remain that the ANOVA has
-  # zero residual degrees of freedom (e.g. one observation per treatment
-  # combination), which makes HSD.test fail on NaN p-values.
+  # "INSUFFICIENT DATA": fewer than two residual degrees of freedom remain
+  # after removing NAs. Two is the minimum HSD.test can handle: R's
+  # qtukey/ptukey return NaN for df < 2, which crashes HSD.test.
   col_skip_label <- function(col_name) {
     col_vals <- aov_data[[col_name]]
     if (length(unique(col_vals[!is.na(col_vals)])) <= 1) return("INVARIANT")
@@ -215,7 +253,7 @@ aovInteractSummaryTable <- function(aov_data,
       return("INVARIANT")
     }
     n_cells <- nrow(unique(non_na_data[group_vars]))
-    if (nrow(non_na_data) - n_cells < 1) return("INSUFFICIENT DATA")
+    if (nrow(non_na_data) - n_cells < 2) return("INSUFFICIENT DATA")
     NA_character_
   }
 
@@ -223,7 +261,6 @@ aovInteractSummaryTable <- function(aov_data,
   # grouping variables themselves) is ignored.
   numeric_cols <- colnames(aov_data)[sapply(aov_data, is.numeric)]
   skip_labels <- vapply(numeric_cols, col_skip_label, character(1))
-  skipped_cols <- numeric_cols[!is.na(skip_labels)]
   model_cols <- numeric_cols[is.na(skip_labels)]
 
   # Fit each model once, caching the ANOVA and Tukey HSD results.
@@ -233,12 +270,27 @@ aovInteractSummaryTable <- function(aov_data,
   # that column's ANOVA only.
   rhs <- paste0("`", group_vars, "`", collapse = " * ")
   models <- lapply(model_cols, function(col_name) {
-    formula <- as.formula(paste0("`", col_name, "` ~ ", rhs))
-    t.anova <- aov(formula, data = aov_data, na.action = na.omit)
-    test2 <- agricolae::HSD.test(t.anova, trt = group_vars, group = TRUE)
-    list(aov = t.anova, tukey = test2)
+    tryCatch({
+      formula <- as.formula(paste0("`", col_name, "` ~ ", rhs))
+      t.anova <- aov(formula, data = aov_data, na.action = na.omit)
+      test2 <- agricolae::HSD.test(t.anova, trt = group_vars, group = TRUE)
+      list(aov = t.anova, tukey = test2)
+    }, error = function(e) e)
   })
   names(models) <- model_cols
+
+  # If a model or Tukey test still fails on degenerate data despite the
+  # checks above, skip that column with a warning naming it rather than
+  # failing the whole table.
+  failed <- vapply(models, inherits, logical(1), what = "error")
+  for (col_name in model_cols[failed]) {
+    warning("Column '", col_name, "' could not be analysed: ",
+            conditionMessage(models[[col_name]]), call. = FALSE)
+    skip_labels[col_name] <- "NOT ANALYSABLE"
+  }
+  models <- models[!failed]
+  model_cols <- model_cols[!failed]
+  skipped_cols <- numeric_cols[!is.na(skip_labels)]
   raw_outputs <- models
 
   # Collect all treatment-combination row names across variables.
@@ -334,14 +386,16 @@ aovInteractSummaryTable <- function(aov_data,
     summary_table <- rbind(summary_table, bh_rows)
   }
 
+  warn_skipped_columns(skip_labels[!is.na(skip_labels)])
+
   if (!is.null(output_file)) {
     openxlsx::write.xlsx(summary_table, output_file, rowNames = FALSE)
   }
-  
+
   if (return_raw) {
     assign(output_name, raw_outputs, envir = .GlobalEnv)
   }
-  
+
   return(summary_table)
 
 }

--- a/man/aovInteractSummaryTable.Rd
+++ b/man/aovInteractSummaryTable.Rd
@@ -32,9 +32,11 @@ This function generates a table of means and key statistical
  Missing values are allowed: observations with an NA in a given variable are
  dropped for that variable's ANOVA only, and group means are computed over
  the observed values. Columns that cannot be analysed are filled with a
- label instead: "INVARIANT" (constant, all NA, or fewer than two levels of
- a grouping variable observed) or "INSUFFICIENT DATA" (too few non-NA
- observations to estimate an error term).
+ label instead, and a warning lists them: "INVARIANT" (constant, all NA,
+ or fewer than two levels of a grouping variable observed),
+ "INSUFFICIENT DATA" (fewer than two residual degrees of freedom left
+ after removing NAs, the minimum Tukey's test can handle), or
+ "NOT ANALYSABLE" (the model or Tukey test failed for another reason).
  It also appends BH-corrected p-values and significance as additional rows.
  The BH correction is applied separately within each effect family (i.e. all
  p-values for a given main effect or interaction are corrected together,

--- a/man/aovSummaryTable.Rd
+++ b/man/aovSummaryTable.Rd
@@ -32,10 +32,12 @@ This function generates a table of means and key statistical
  columns (other than the grouping variable) are ignored. Missing values are
  allowed: observations with an NA in a given variable are dropped for that
  variable's ANOVA only, and group means are computed over the observed
- values. Columns that cannot be analysed are filled with a label instead:
- "invariant" (constant, all NA, or fewer than two groups observed) or
- "insufficient data" (too few non-NA observations to estimate an error
- term). It also
+ values. Columns that cannot be analysed are filled with a label instead,
+ and a warning lists them: "invariant" (constant, all NA, or fewer than
+ two groups observed), "insufficient data" (fewer than two residual
+ degrees of freedom left after removing NAs, the minimum Tukey's test can
+ handle), or "not analysable" (the model or Tukey test failed for another
+ reason). It also
  appends rows for the Benjamini–Hochberg (BH) corrected p-values and significance.
  The output includes a “Type” column so that the row labels are exported to Excel.
 }

--- a/tests/testthat/test_aovInteractSummaryTable.R
+++ b/tests/testthat/test_aovInteractSummaryTable.R
@@ -45,7 +45,9 @@ test_that("aovInteractSummaryTable handles constant-value (invariant) columns wi
   # Add a column that is completely constant
   greenhouse1_data$constant_col <- 42.0
 
-  result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  result <- suppressWarnings(
+    aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  )
 
   expect_s3_class(result, "data.frame")
   expect_true("constant_col" %in% colnames(result))
@@ -63,11 +65,13 @@ test_that("aovInteractSummaryTable handles columns present for only one factor l
     NA_real_
   )
 
-  expect_no_error({
+  expect_no_error(suppressWarnings({
     result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
-  })
+  }))
 
-  result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  result <- suppressWarnings(
+    aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  )
   expect_true("single_factor_col" %in% colnames(result))
   expect_true(all(result[["single_factor_col"]] == "INVARIANT"))
 })
@@ -124,11 +128,13 @@ test_that("aovSummaryTable handles columns present for only one factor level wit
     NA_real_
   )
 
-  expect_no_error({
+  expect_no_error(suppressWarnings({
     result <- aovSummaryTable(greenhouse1_data, group_var = "variety")
-  })
+  }))
 
-  result <- aovSummaryTable(greenhouse1_data, group_var = "variety")
+  result <- suppressWarnings(
+    aovSummaryTable(greenhouse1_data, group_var = "variety")
+  )
   expect_true("single_factor_col" %in% colnames(result))
   expect_true(all(result[["single_factor_col"]] == "invariant"))
 })
@@ -162,7 +168,7 @@ test_that("aovSummaryTable treats constant-except-NA and all-NA columns as invar
     all_na = NA_real_
   )
 
-  result <- aovSummaryTable(na_data, group_var = "EtOH")
+  result <- suppressWarnings(aovSummaryTable(na_data, group_var = "EtOH"))
 
   expect_true(all(result[["const_na"]] == "invariant"))
   expect_true(all(result[["all_na"]] == "invariant"))
@@ -187,7 +193,9 @@ test_that("aovInteractSummaryTable computes means over observed values when NAs 
   greenhouse1_data$const_na <- 42
   greenhouse1_data$const_na[2] <- NA_real_
 
-  result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  result <- suppressWarnings(
+    aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  )
 
   # The treatment combination that lost an observation should show the mean
   # of the remaining observed values.
@@ -203,36 +211,92 @@ test_that("aovInteractSummaryTable computes means over observed values when NAs 
   expect_false(any(grepl("NaN", result[["tubers_na"]])))
 })
 
-test_that("aovSummaryTable skips columns with zero residual df instead of crashing", {
-  # 'sparse' has one observed value per group: the ANOVA would have zero
-  # residual degrees of freedom, which used to crash HSD.test with
-  # "missing value where TRUE/FALSE needed" (NaN Tukey p-values).
+test_that("aovSummaryTable skips columns with fewer than 2 residual df instead of crashing", {
+  # HSD.test crashes with "missing value where TRUE/FALSE needed" when the
+  # ANOVA has fewer than two residual degrees of freedom, because R's
+  # qtukey/ptukey return NaN for df < 2. 'sparse0' has one observed value
+  # per group (df = 0); 'sparse1' has three observations across two groups
+  # (df = 1).
   na_data <- data.frame(
     EtOH = c("CTRL", "CTRL", "CTRL", "9PC", "9PC", "9PC"),
     Dp_gluc = c(18.15, 14.89, 12.55, NA, 13.47, 10.25),
-    sparse = c(11.2, NA, NA, NA, 9.8, NA)
+    sparse0 = c(11.2, NA, NA, NA, 9.8, NA),
+    sparse1 = c(6.14, NA, 5.34, NA, NA, 3.07)
   )
 
-  expect_no_error(result <- aovSummaryTable(na_data, group_var = "EtOH"))
-  expect_true(all(result[["sparse"]] == "insufficient data"))
+  expect_no_error(suppressWarnings(
+    result <- aovSummaryTable(na_data, group_var = "EtOH")
+  ))
+  expect_true(all(result[["sparse0"]] == "insufficient data"))
+  expect_true(all(result[["sparse1"]] == "insufficient data"))
   # The healthy column is still analysed as usual.
   expect_true(startsWith(result[result$Type == "9PC", "Dp_gluc"],
                          as.character(signif(mean(c(13.47, 10.25)), 4))))
 })
 
-test_that("aovInteractSummaryTable skips columns with zero residual df instead of crashing", {
+test_that("aovInteractSummaryTable skips columns with fewer than 2 residual df instead of crashing", {
   greenhouse1_data <- greenhouse$greenhouse1
-  # Keep exactly one observation per variety:method cell -> zero residual df.
   combos <- paste(greenhouse1_data$variety, greenhouse1_data$method, sep = ":")
-  greenhouse1_data$sparse <- ifelse(duplicated(combos), NA_real_,
-                                    greenhouse1_data$tubers)
+  # One observation per variety:method cell -> zero residual df.
+  greenhouse1_data$sparse0 <- ifelse(duplicated(combos), NA_real_,
+                                     greenhouse1_data$tubers)
+  # One extra observation on top of that -> one residual df (qtukey NaN).
+  greenhouse1_data$sparse1 <- greenhouse1_data$sparse0
+  greenhouse1_data$sparse1[which(is.na(greenhouse1_data$sparse1))[1]] <-
+    greenhouse1_data$tubers[which(is.na(greenhouse1_data$sparse0))[1]]
 
-  expect_no_error({
+  expect_no_error(suppressWarnings({
     result <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
-  })
-  expect_true(all(result[["sparse"]] == "INSUFFICIENT DATA"))
+  }))
+  expect_true(all(result[["sparse0"]] == "INSUFFICIENT DATA"))
+  expect_true(all(result[["sparse1"]] == "INSUFFICIENT DATA"))
   # The healthy columns are still analysed as usual.
   expect_true(any(grepl("^P-value-variety$", result$Type)))
   expect_false(any(grepl("NaN", result[["tubers"]])))
+})
+
+test_that("aovSummaryTable warns with the names and reasons of skipped columns", {
+  na_data <- data.frame(
+    EtOH = c("CTRL", "CTRL", "CTRL", "9PC", "9PC", "9PC"),
+    Dp_gluc = c(18.15, 14.89, 12.55, NA, 13.47, 10.25),
+    Vitisin_A = c(NA, NA, NA, NA, NA, 3.11),
+    Unassigned = c(4.72, NA, NA, NA, NA, 5.66)
+  )
+
+  expect_warning(
+    aovSummaryTable(na_data, group_var = "EtOH"),
+    "Vitisin_A \\(invariant\\), Unassigned \\(insufficient data\\)"
+  )
+})
+
+test_that("aovInteractSummaryTable warns with the names and reasons of skipped columns", {
+  greenhouse1_data <- greenhouse$greenhouse1
+  greenhouse1_data$constant_col <- 42.0
+
+  expect_warning(
+    aovInteractSummaryTable(greenhouse1_data, c("variety", "method")),
+    "constant_col \\(INVARIANT\\)"
+  )
+})
+
+test_that("unexpected per-column failures are labelled and warned about, not fatal", {
+  skip_if_not_installed("testthat", "3.1.7")
+  local_mocked_bindings(HSD.test = function(...) stop("boom"),
+                        .package = "agricolae")
+
+  na_data <- data.frame(
+    EtOH = c("CTRL", "CTRL", "CTRL", "9PC", "9PC", "9PC"),
+    Dp_gluc = c(18.15, 14.89, 12.55, NA, 13.47, 10.25)
+  )
+  w <- capture_warnings(result <- aovSummaryTable(na_data, group_var = "EtOH"))
+  expect_true(any(grepl("Column 'Dp_gluc' could not be analysed: boom", w)))
+  expect_true(all(result[["Dp_gluc"]] == "not analysable"))
+
+  greenhouse1_data <- greenhouse$greenhouse1
+  w2 <- capture_warnings(
+    result2 <- aovInteractSummaryTable(greenhouse1_data, c("variety", "method"))
+  )
+  expect_true(any(grepl("Column 'tubers' could not be analysed: boom", w2)))
+  expect_true(any(grepl("tubers \\(NOT ANALYSABLE\\)", w2)))
 })
 


### PR DESCRIPTION
## Summary
Follow-up to #26, which required only ≥1 residual degree of freedom. R's `qtukey`/`ptukey` return NaN for df < 2, so a column with e.g. three observations across two groups (df = 1) still crashed `agricolae::HSD.test()` with `missing value where TRUE/FALSE needed`. This PR fixes that and adds the console warning requested in review: skipped columns are now named, with reasons, in a warning as well as labelled in the table.

## Key Changes
Identical changes to `aovSummaryTable` and `aovInteractSummaryTable`:
- The `insufficient data` pre-check now requires at least **two** residual degrees of freedom (the minimum HSD.test can handle)
- Each column's model fit and Tukey test are wrapped in `tryCatch`: any unforeseen failure is labelled `not analysable`/`NOT ANALYSABLE` with a warning naming the column and the original error, instead of taking the whole table down
- Both functions emit a warning listing every skipped column and the reason, e.g.
  `The following columns could not be analysed and were filled with a label instead: Unassigned (insufficient data), Vitisin_A (invariant). ... please check them, and consider removing them from the dataset prior to analysis.`
- Documentation updated to describe the three labels and the warning (man pages regenerated)

## Tests
- Regression tests for the df = 1 crash in both functions
- Tests asserting the warning names skipped columns with their reasons
- Mocked-failure tests exercising the `tryCatch` path in both functions
- Full existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016egxMJdvUmZ3qUGoaMgriS

---
_Generated by [Claude Code](https://claude.ai/code/session_016egxMJdvUmZ3qUGoaMgriS)_